### PR TITLE
Fix params override.

### DIFF
--- a/interceptor/template.js
+++ b/interceptor/template.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors
+ * Copyright 2015-2018 the original author or authors
  * @license MIT, see LICENSE.txt for details
  *
  * @author Scott Andrews
@@ -36,7 +36,7 @@ module.exports = interceptor({
 		var template, params;
 
 		template = request.path || config.template;
-		params = mixin({}, request.params, config.params);
+		params = mixin({}, config.params, request.params);
 
 		request.path = uriTemplate.expand(template, params);
 		delete request.params;


### PR DESCRIPTION
This PR changes the order the params are merged so that the template interceptor config params can be overwritten by the request params.

Before this commit the config params passed in when wrapping the client
with the template interceptor could not be overwritten by the request
params passed in when invoking the client.

By changing the order of the arguments in the interceptor/template.js
mixin function, the config params (defualt params) can be overwritten by
the request params.

The docs for template interceptor defines the config params property as:

> default params to be combined with request.params

The template config params should be a default, as in they can be overwritten by the request.params. However the template config params cannot be overwritten by the request params.

This is the behavior I expected from reading the docs:
```
var client = rest.wrap(template, { params: { lang: 'en-us', section: 'introduction' } })

client({
  path: '/example/path/{section}{?lang}',
  params: {
    section: 'glossary'
  }
})

// response.url -> /example/path/glossary?lang=en-us
```

This is current behavior:
```
var client = rest.wrap(template, { params: { lang: 'en-us', section: 'introduction' } })

client({
  path: '/example/path/{section}{?lang}',
  params: {
    section: 'glossary'
  }
})

// response.url -> /example/path/introduction?lang=en-us
```

Also in this PR:

- Update year in licence block

- Add test to confirm config params overwrite behavior

This PR passes all test.

Issue: #180 